### PR TITLE
Fix a race on error reporting

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -79,11 +79,14 @@ func (p *Publisher) EventFunc(ctx context.Context, fn EventFunc) {
 	defer func() {
 		err := recoverErr(nil, recover())
 
-		if p.errors == nil {
-			return
-		}
-
 		if err != nil {
+			p.errorsMu.Lock()
+			defer p.errorsMu.Unlock()
+
+			if p.errors == nil {
+				return
+			}
+
 			// Attempt to publish the panic
 			// nolint:gomnd
 			go func(ctx context.Context, cancel context.CancelFunc) {


### PR DESCRIPTION
# Description

Fix for race:
```
Read at 0x00c00021bfe0 by goroutine 15:
  go.devnw.com/event.(*Publisher).EventFunc.func1()
      /home/matt/go/pkg/mod/go.devnw.com/event@v1.0.2/publisher.go:82 +0x89
...

Previous write at 0x00c00021bfe0 by goroutine 57:
  go.devnw.com/event.(*Publisher).ReadErrors()
      /home/matt/go/pkg/mod/go.devnw.com/event@v1.0.2/publisher.go:64 +0x113
...
```
## Checklist

* [ ] Documentation
  * [ ] Code
  * [ ] Updated README or /docs/
* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
* [x] I have read the [contributing guide][]

[contributing guide]: https://github.com/devnw/.github/blob/main/CONTRIBUTING.md
